### PR TITLE
Improve mobile UI/UX for chat widget

### DIFF
--- a/src/components/chat/ChatWidget.jsx
+++ b/src/components/chat/ChatWidget.jsx
@@ -87,10 +87,9 @@ export function ChatWidget() {
       <button
         onClick={() => setIsOpen(true)}
         className={cn(
-          'fixed bottom-6 right-6 z-50 h-14 w-14 rounded-full shadow-lg transition-all duration-300',
-          'bg-white hover:scale-110 hover:shadow-xl',
-          'flex items-center justify-center',
-          'animate-bounce hover:animate-none',
+          'fixed bottom-4 right-4 z-50 size-12 rounded-full shadow-lg transition-all duration-300 md:bottom-6 md:right-6 md:size-14',
+          'flex items-center justify-center bg-white',
+          'animate-bounce hover:scale-110 hover:animate-none hover:shadow-xl',
           'border-2 border-primary/20'
         )}
         aria-label="Open chat"
@@ -100,12 +99,12 @@ export function ChatWidget() {
           alt="Saroj AI"
           width={48}
           height={48}
-          className="size-10 object-contain"
+          className="size-8 object-contain md:size-10"
           priority
         />
         
         {/* Notification badge */}
-        <span className="absolute -right-1 -top-1 flex size-5 items-center justify-center rounded-full bg-accent1 text-xs font-semibold text-white">
+        <span className="absolute -right-1 -top-1 flex size-4 items-center justify-center rounded-full bg-accent1 text-[10px] font-semibold text-white md:size-5 md:text-xs">
           AI
         </span>
       </button>
@@ -115,17 +114,20 @@ export function ChatWidget() {
   return (
     <div
       className={cn(
-        'fixed bottom-6 right-6 z-50 flex flex-col',
-        'w-full max-w-md rounded-lg border border-primary/20 bg-background shadow-2xl',
+        'fixed z-50 flex flex-col',
+        // Mobile: full width with small margins, Desktop: fixed width at bottom-right
+        'bottom-0 left-0 right-0 mx-2 mb-2 md:bottom-6 md:left-auto md:right-6 md:mx-0 md:mb-0',
+        'w-auto rounded-lg border border-primary/20 bg-background shadow-2xl md:w-full md:max-w-md',
         'transition-all duration-300',
-        isMinimized ? 'h-14' : 'h-[600px] md:h-[650px]'
+        // Mobile: vh-based height, Desktop: fixed height
+        isMinimized ? 'h-14' : 'h-[calc(100vh-8rem)] md:h-[600px]'
       )}
     >
       {/* Header */}
-      <div className="flex items-center justify-between rounded-t-lg bg-gradient-to-r from-primary to-accent1 p-3 text-white md:p-4">
-        <div className="flex min-w-0 items-center gap-2 md:gap-3">
+      <div className="flex items-center justify-between rounded-t-lg bg-gradient-to-r from-primary to-accent1 p-2.5 text-white md:p-3">
+        <div className="flex min-w-0 items-center gap-2">
           <div className="relative shrink-0">
-            <div className="flex size-8 items-center justify-center overflow-hidden rounded-full bg-white p-0.5 md:size-10 md:p-1">
+            <div className="flex size-7 items-center justify-center overflow-hidden rounded-full bg-white p-0.5 md:size-9 md:p-1">
               <Image
                 src="/assets/icons/sarojai.svg"
                 alt="Saroj AI"
@@ -135,21 +137,21 @@ export function ChatWidget() {
                 priority
               />
             </div>
-            <span className="absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border-2 border-white bg-green-400 md:size-3"></span>
+            <span className="absolute -bottom-0.5 -right-0.5 size-2 rounded-full border border-white bg-green-400 md:size-2.5"></span>
           </div>
           <div className="min-w-0 flex-1">
             <h3 className="truncate text-xs font-semibold md:text-sm">Saroj&apos;s AI Assistant</h3>
-            <p className="text-[10px] opacity-90 md:text-xs">Online</p>
+            <p className="text-[9px] opacity-90 md:text-[10px]">Online</p>
           </div>
         </div>
         
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5 md:gap-2">
           <button
             onClick={() => setIsMinimized(!isMinimized)}
-            className="rounded-full p-1.5 transition-colors hover:bg-white/20"
+            className="rounded-full p-1 transition-colors hover:bg-white/20 md:p-1.5"
             aria-label={isMinimized ? 'Maximize' : 'Minimize'}
           >
-            <svg className="size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="size-4 md:size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               {isMinimized ? (
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
               ) : (
@@ -159,10 +161,10 @@ export function ChatWidget() {
           </button>
           <button
             onClick={() => setIsOpen(false)}
-            className="rounded-full p-1.5 transition-colors hover:bg-white/20"
+            className="rounded-full p-1 transition-colors hover:bg-white/20 md:p-1.5"
             aria-label="Close chat"
           >
-            <svg className="size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="size-4 md:size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
@@ -172,26 +174,26 @@ export function ChatWidget() {
       {/* Messages */}
       {!isMinimized && (
         <>
-          <div className="flex-1 space-y-4 overflow-y-auto scroll-smooth p-4">
+          <div className="flex-1 space-y-3 overflow-y-auto scroll-smooth p-3 md:space-y-4 md:p-4">
             {messages.map((m) => (
               <div
                 key={m.id}
                 className={cn(
-                  'animate-in fade-in slide-in-from-bottom-2 rounded-lg p-3 text-sm duration-300',
+                  'animate-in fade-in slide-in-from-bottom-2 rounded-lg p-2.5 text-xs duration-300 md:p-3 md:text-sm',
                   m.role === 'user'
-                    ? 'ml-8 border border-primary/20 bg-primary/10 text-primary'
-                    : 'mr-8 border border-secondary/20 bg-secondary/10 text-secondary'
+                    ? 'ml-6 border border-primary/20 bg-primary/10 text-primary md:ml-8'
+                    : 'mr-6 border border-secondary/20 bg-secondary/10 text-secondary md:mr-8'
                 )}
               >
                 <div
-                  className="prose prose-sm max-w-none leading-relaxed"
+                  className="prose prose-sm max-w-none leading-relaxed [&_a]:break-words"
                   dangerouslySetInnerHTML={{ __html: formatMessage(m.content) }}
                 />
               </div>
             ))}
             
             {isLoading && (
-              <div className="border-secondary/20 bg-secondary/10 mr-8 rounded-lg border p-3 text-sm text-secondary">
+              <div className="border-secondary/20 bg-secondary/10 mr-6 rounded-lg border p-2.5 text-xs text-secondary md:mr-8 md:p-3 md:text-sm">
                 <div className="flex items-center gap-2">
                   <div className="size-2 animate-bounce rounded-full bg-primary" style={{ animationDelay: '0ms' }} />
                   <div className="size-2 animate-bounce rounded-full bg-primary" style={{ animationDelay: '150ms' }} />
@@ -201,7 +203,7 @@ export function ChatWidget() {
             )}
             
             {error && (
-              <div className="mr-8 rounded-lg border border-red-300 bg-red-100 p-3 text-sm text-red-600 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+              <div className="mr-6 rounded-lg border border-red-300 bg-red-100 p-2.5 text-xs text-red-600 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400 md:mr-8 md:p-3 md:text-sm">
                 ⚠️ Error: {error.message}
               </div>
             )}
@@ -210,14 +212,14 @@ export function ChatWidget() {
           </div>
 
           {/* Input */}
-          <form onSubmit={onSubmit} className="border-primary/20 border-t p-4">
+          <form onSubmit={onSubmit} className="border-primary/20 shrink-0 border-t p-3 md:p-4">
             <div className="flex gap-2">
               <input
                 value={input}
                 onChange={handleInputChange}
-                placeholder="Ask about blog posts, work, or social links..."
+                placeholder="Ask me anything..."
                 className={cn(
-                  'flex-1 rounded-lg border border-primary/20 bg-background px-4 py-2.5 text-sm',
+                  'flex-1 rounded-lg border border-primary/20 bg-background px-3 py-2 text-xs md:px-4 md:py-2.5 md:text-sm',
                   'placeholder:text-secondary/50',
                   'focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20',
                   'disabled:cursor-not-allowed disabled:opacity-50'
@@ -228,25 +230,25 @@ export function ChatWidget() {
                 type="submit"
                 disabled={isLoading || !input.trim()}
                 className={cn(
-                  'flex items-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-white',
+                  'flex shrink-0 items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-medium text-white md:gap-2 md:px-4 md:py-2.5 md:text-sm',
                   'transition-colors hover:bg-primary/90',
                   'disabled:cursor-not-allowed disabled:opacity-50'
                 )}
               >
                 {isLoading ? (
                   <>
-                    <svg className="size-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <svg className="size-3.5 animate-spin md:size-4" fill="none" viewBox="0 0 24 24">
                       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                       <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
                     </svg>
-                    <span className="hidden sm:inline">Thinking...</span>
+                    <span className="hidden md:inline">Thinking...</span>
                   </>
                 ) : (
                   <>
-                    <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="size-3.5 md:size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
                     </svg>
-                    <span className="hidden sm:inline">Send</span>
+                    <span className="hidden md:inline">Send</span>
                   </>
                 )}
               </button>
@@ -254,11 +256,11 @@ export function ChatWidget() {
             
             {/* Quick suggestions */}
             {messages.length === 1 && (
-              <div className="mt-3 flex flex-wrap gap-2">
+              <div className="mt-2 flex flex-wrap gap-1.5 md:mt-3 md:gap-2">
                 {[
                   'What does Saroj write about?',
-                  'Show me his latest posts',
-                  'Where can I find his work?'
+                  'Show me latest posts',
+                  'Find his work'
                 ].map((suggestion, idx) => (
                   <button
                     key={idx}
@@ -266,7 +268,7 @@ export function ChatWidget() {
                     onClick={() => {
                       handleInputChange({ target: { value: suggestion } })
                     }}
-                    className="border-secondary/20 bg-secondary/10 hover:bg-secondary/20 rounded-full border px-3 py-1 text-xs text-secondary transition-colors"
+                    className="border-secondary/20 bg-secondary/10 hover:bg-secondary/20 rounded-full border px-2.5 py-1 text-[10px] text-secondary transition-colors md:px-3 md:text-xs"
                   >
                     {suggestion}
                   </button>


### PR DESCRIPTION
🎨 Mobile-First Design Improvements:

Layout & Positioning:
- Full-width chat on mobile with small margins (vs fixed width on desktop)
- Viewport-based height: calc(100vh-8rem) for better mobile screen usage
- Reduced bottom/right positioning from 6 to 4 units on mobile
- Chat appears at screen bottom on mobile, bottom-right on desktop

Typography & Spacing:
- Smaller font sizes on mobile (9px-12px vs 10px-14px desktop)
- Reduced padding throughout: p-2.5/p-3 mobile vs p-3/p-4 desktop
- Compact header: size-7 icon mobile vs size-9 desktop
- Tighter spacing: gap-1.5 mobile vs gap-2 desktop
- Message margins: ml-6/mr-6 mobile vs ml-8/mr-8 desktop

Input & Interaction:
- Shorter placeholder: "Ask me anything..." (mobile-friendly)
- Compact input: px-3 py-2 mobile vs px-4 py-2.5 desktop
- Smaller icons: size-3.5 mobile vs size-4 desktop
- Suggestion buttons: text-[10px] mobile vs text-xs desktop

Floating Button:
- Smaller size: 48px mobile vs 56px desktop
- Closer to edge: bottom-4 right-4 vs bottom-6 right-6
- Badge: size-4 mobile vs size-5 desktop

Content:
- Added word-break for long links: [&_a]:break-words
- Shortened suggestion text for mobile screens
- Made form shrink-0 to prevent input squishing

Result: Clean, professional mobile experience optimized for smaller screens